### PR TITLE
feat: implement main branch mode for working without issues/worktrees

### DIFF
--- a/lib/issue.sh
+++ b/lib/issue.sh
@@ -275,6 +275,73 @@ run_prompt_mode() {
     fi
 }
 
+# Main branch mode - work directly on main without issues/worktrees
+run_main_mode() {
+    local prompt="$1"
+    local use_async="$2"
+    
+    echo -e "${GREEN}Claude Code Main Branch Mode${NC}"
+    echo -e "${BLUE}Working directly on main branch without creating issues or worktrees${NC}"
+    
+    if [ -n "$prompt" ]; then
+        echo -e "${BLUE}Prompt: $prompt${NC}"
+    fi
+    
+    # If in synchronous mode, confirm
+    if [ "$use_async" != "true" ]; then
+        echo ""
+        echo -e "${YELLOW}Do you want to start Claude Code on the main branch? (y/N):${NC}"
+        read -r confirm
+        
+        if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+            echo -e "${YELLOW}Main branch mode canceled${NC}"
+            exit 0
+        fi
+    fi
+    
+    # Git status check
+    check_git_status
+    
+    # Make sure we're on main branch
+    cd "$REPO_ROOT"
+    local current_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$current_branch" != "main" ] && [ "$current_branch" != "master" ]; then
+        echo -e "${YELLOW}Switching to main branch...${NC}"
+        git checkout main || git checkout master || {
+            echo -e "${RED}Error: Cannot switch to main branch${NC}"
+            exit 1
+        }
+    fi
+    
+    # Pull latest changes
+    echo -e "${BLUE}Pulling latest changes from origin...${NC}"
+    git pull origin main || git pull origin master || {
+        echo -e "${YELLOW}Warning: Could not pull latest changes${NC}"
+    }
+    
+    # If no prompt provided, ask for it
+    if [ -z "$prompt" ]; then
+        echo -e "${BLUE}Please enter the task or prompt for Claude Code:${NC}"
+        read -r prompt
+        
+        if [ -z "$prompt" ]; then
+            echo -e "${RED}Error: No prompt provided${NC}"
+            exit 1
+        fi
+    fi
+    
+    # Claude Code execution on main branch
+    if [ "$use_async" = "true" ]; then
+        # tmux mode
+        check_tmux
+        run_claude_tmux "$prompt" "$REPO_ROOT" "main" "" "false"
+    else
+        # tmux mode (synchronous/attach)
+        check_tmux
+        run_claude_tmux "$prompt" "$REPO_ROOT" "main" "" "true"
+    fi
+}
+
 # Issue creation mode (simple version)
 create_issue() {
     local title="$1"

--- a/lib/session.sh
+++ b/lib/session.sh
@@ -108,8 +108,8 @@ show_tmux_sessions() {
     
     local has_sessions=false
     
-    # Get tmux session list (issue-* only)
-    for session in $(tmux list-sessions -F "#{session_name}" 2>/dev/null | grep -E "^${PROJECT_NAME}-issue-" || true); do
+    # Get tmux session list (issue-* and main-*)
+    for session in $(tmux list-sessions -F "#{session_name}" 2>/dev/null | grep -E "^${PROJECT_NAME}-(issue|main)-" || true); do
         has_sessions=true
         local created=$(tmux list-sessions -F "#{session_name} #{session_created}" 2>/dev/null | grep "^$session " | awk '{print $2}')
         local created_date=$(date -r "$created" "+%Y-%m-%d %H:%M:%S" 2>/dev/null || echo "Unknown")
@@ -145,6 +145,9 @@ show_tmux_sessions() {
             if [ -d "$worktree_dir" ]; then
                 echo "  Worktree: $worktree_dir"
             fi
+        elif [[ "$session" =~ ^${PROJECT_NAME}-main- ]]; then
+            echo "  Mode: Main branch (no issue/worktree)"
+            echo "  Working directory: $REPO_ROOT"
         fi
         
         echo ""
@@ -290,6 +293,10 @@ run_claude_tmux() {
     local session_name=""
     if [ -n "$issue_number" ] && [ "$issue_number" != "" ]; then
         session_name="${PROJECT_NAME}-issue-${issue_number}"
+    elif [ "$mode" = "main" ]; then
+        # Main branch mode - use project name and timestamp
+        local timestamp=$(date +%Y%m%d_%H%M%S)
+        session_name="${PROJECT_NAME}-main-${timestamp}"
     else
         # Timestamp for prompt mode
         local timestamp=$(date +%Y%m%d_%H%M%S)

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -76,6 +76,7 @@ Usage: $0 [command] [options]
 
 Commands:
   fix <issue>          Fix a single issue with AI assistance
+  main [prompt]        Start Claude Code on main branch without issues/worktrees
   batch <issues...>    Process multiple issues in parallel  
   sessions             List all active vive sessions
   attach <issue>       Attach to a running session
@@ -93,6 +94,8 @@ Options:
 
 Examples:
   $0 fix 42                      Fix issue #42
+  $0 main "Add logging"          Run Claude Code on main branch with prompt
+  $0 main -s                     Run Claude Code on main branch (sync mode)
   $0 batch 41 42 43              Process issues #41, #42, #43 in parallel
   $0 attach 42                   Attach to session for issue #42
   $0 sessions                    List all active sessions

--- a/vive.sh
+++ b/vive.sh
@@ -189,6 +189,28 @@ main() {
         # Interactive shell in worktree
         shift # Remove "shell"
         shell_in_worktree "$@"
+    elif [ "$1" = "main" ]; then
+        # Main branch mode - work without issues/worktrees
+        shift # Remove "main"
+        local prompt=""
+        local use_async="true"
+        
+        # Parse arguments
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                -s|--sync)
+                    use_async="false"
+                    shift
+                    ;;
+                *)
+                    # Everything else is the prompt
+                    prompt="$*"
+                    break
+                    ;;
+            esac
+        done
+        
+        run_main_mode "$prompt" "$use_async"
     else
         # Unknown command
         echo -e "${RED}Error: Unknown command '$1'${NC}"


### PR DESCRIPTION
## Summary
- Implements issue #13 - adds ability to work on main branch without creating issues or worktrees
- Adds new `vive main` command for quick tasks that don't need the full issue/worktree workflow
- Enables users to run Claude Code directly on the main branch

## Test plan
- [ ] Run `vive main "test prompt"` to verify main branch mode works
- [ ] Run `vive main -s` to test synchronous mode
- [ ] Run `vive sessions` to verify main branch sessions are displayed correctly
- [ ] Verify help documentation shows the new command

🤖 Generated with [Claude Code](https://claude.ai/code)