### PR TITLE
fix: 完了通知の英語メッセージを自然な英語に修正 #12

### DIFF
--- a/test_notification.sh
+++ b/test_notification.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Test script for notification messages
+
+echo "Testing notification messages..."
+
+# Test completion notification
+echo "Testing completion notification:"
+say "Agent 12 has completed work"
+sleep 2
+
+# Test resume notification
+echo "Testing resume notification:"
+say "Agent 12 has resumed work"
+sleep 2
+
+# Test error notification
+echo "Testing error notification:"
+say "Agent 12 detected unknown box pattern. Check required."
+sleep 2
+
+echo "All notifications tested."

--- a/watchdog.exp
+++ b/watchdog.exp
@@ -146,9 +146,9 @@ proc detect_completion {output seconds_since_change} {
 # エージェント名を取得する関数
 proc get_agent_name {session_name} {
     if {[regexp {issue-([0-9]+)} $session_name match issue_num]} {
-        return "エージェント $issue_num"
+        return "Agent $issue_num"
     }
-    return "エージェント"
+    return "Agent"
 }
 
 # 音声通知を送信する関数


### PR DESCRIPTION
## Summary
- 完了通知の英語メッセージにおける日本語訛りを修正
- "エージェント N" を "Agent N" に変更し、より自然な英語表現に改善

## Changes
- `watchdog.exp`: エージェント名の取得関数で日本語の「エージェント」を英語の "Agent" に変更
- `test_notification.sh`: 音声通知のテストスクリプトを追加

## Test plan
- [ ] `./test_notification.sh` を実行して音声通知が自然な英語で再生されることを確認
- [ ] viveセッションで実際にタスクを完了させ、通知メッセージが正しく表示されることを確認

Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)