### PR TITLE
fix: prevent watch_* file creation (#10)

### DIFF
--- a/lib/session.sh
+++ b/lib/session.sh
@@ -271,7 +271,8 @@ show_tmux_logs() {
         echo ""
         
         # watch command for real-time display
-        watch -n 1 "tmux capture-pane -t '$session_name:0.0' -p 2>/dev/null || echo 'Session $session_name not found'"
+        # Use -t option to disable title (prevents creating watch_* files)
+        watch -t -n 1 "tmux capture-pane -t '$session_name:0.0' -p 2>/dev/null || echo 'Session $session_name not found'"
     else
         echo -e "${GREEN}Session '$session_name' log (latest 50 lines):${NC}"
         echo ""


### PR DESCRIPTION
## Summary
- Fixed an issue where watch command created temporary files like `watch_20250607-172704` in the current directory
- Added `-t` option to the watch command to disable title generation, preventing unwanted file creation

## Test plan
- [x] Created and ran test script to verify no `watch_*` files are created when using the watch command
- [x] Confirmed the watch command still functions correctly for displaying tmux session logs in real-time

🤖 Generated with [Claude Code](https://claude.ai/code)