### PR TITLE
style: unify pane border colors to DarkGray

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -88,11 +88,7 @@ fn render_sidebar(frame: &mut Frame, area: Rect, state: &mut AppState) {
             Block::default()
                 .borders(Borders::ALL)
                 .title("Projects")
-                .border_style(
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
+                .border_style(Style::default().fg(Color::DarkGray)),
         )
         // Use empty highlight symbol to avoid interfering with item content
         .highlight_symbol("")
@@ -384,9 +380,12 @@ fn render_dashboard_preview(frame: &mut Frame, area: Rect, state: &AppState, tit
         };
 
         // Issue #65: Wrapping disabled (Ratatui default) for consistent scroll calculation
-        let pane_widget = Paragraph::new(text)
-            .scroll((scroll_offset, 0))
-            .block(Block::default().borders(Borders::ALL).title(pane_title));
+        let pane_widget = Paragraph::new(text).scroll((scroll_offset, 0)).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(pane_title)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        );
         frame.render_widget(pane_widget, *chunk);
     }
 }


### PR DESCRIPTION
## Summary
- Projects、Preview、ダッシュボードペインの枠線色を`DarkGray`に統一
- 視覚的な一貫性を向上

## Test plan
- [ ] アプリを起動してProjectsペインの枠線がDarkGrayになっていることを確認
- [ ] ダッシュボードモードでペインの枠線がDarkGrayになっていることを確認
- [ ] Previewペインの枠線が変わらずDarkGrayであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)