### PR TITLE
feat: support configurable one-liner kickstart command with variable substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ enter = "ghostty -e tmux attach -t {session_id}"
 # タスク作成時の自動キックスタート設定
 [auto_kickstart]
 # 手動タスク作成時に実行するコマンド
+# 利用可能なプレースホルダー: {session_id}, {branch_name}, {project_name}, {worktree_path}
 manual_command = "claude"
-# Issue選択でタスク作成時に実行するコマンド
-issue_command = "/fix {issue_number}"
+# Issue選択でタスク作成時に実行するコマンド（ワンライナー形式）
+# 利用可能なプレースホルダー: {issue_number}, {session_id}, {branch_name}, {project_name}, {worktree_path}
+issue_command = "claude \"/fix {issue_number}\""
 ```
 
 ## ドキュメント

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -63,9 +63,10 @@ n = "code {path}"
 1.  Git Worktree の作成（新しいディレクトリの確保）
 2.  新規ブランチの作成
 3.  専用Tmuxセッションの立ち上げ
-4.  **Auto-Kickstart**: Claude Codeの自動起動と初期コマンドの送信（デフォルト有効、Tabキーでトグル可能）
-    - Manual入力モード: `claude --print-architecture` を送信
-    - Issue Pickerモード: `/fix {issue_number}` を送信してIssueの修正を開始
+4.  **Auto-Kickstart**: 設定されたコマンドの自動実行（デフォルト有効、Tabキーでトグル可能）
+    - Manual入力モード: `manual_command` で設定されたコマンドを実行（例: `claude`）
+    - Issue Pickerモード: `issue_command` で設定されたワンライナーを実行（例: `claude "/fix {issue_number}"`）
+    - 利用可能なプレースホルダー: `{issue_number}`, `{session_id}`, `{branch_name}`, `{project_name}`, `{worktree_path}`
 
 ### 3. コンテキストの切り替え (Switching)
 タスクを選択して Enter を押すだけで、そのタスクのTmuxセッションに接続（Attach）します。

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -19,9 +19,10 @@ Viveは、複数のGit Worktree、Tmuxセッション、およびAIエージェ�
 - [x] **Create Task**: Vive上から直接 `git worktree add` を実行し、新しいタスク（ブランチ）を作成する。
     - **Manual**: ブランチ名を手動入力する。
     - **Pick from Issue**: GitHub Issueリストからタスクを選択し、`feature/issue-{番号}` 形式でブランチを自動生成する。
-    - **Auto-Kickstart**: タスク作成後、自動的にClaude Codeを起動してコマンドを送信する（デフォルト有効、Tabキーでトグル可能）。
-        - Manual: `claude --print-architecture` を送信。
-        - Issue Picker: `/fix {issue_number}` を送信してIssueの修正を開始。
+    - **Auto-Kickstart**: タスク作成後、設定されたコマンドを自動実行する（デフォルト有効、Tabキーでトグル可能）。
+        - Manual: `manual_command` で設定されたコマンドを実行（例: `claude`）。
+        - Issue Picker: `issue_command` で設定されたワンライナーコマンドを実行（例: `claude "/fix {issue_number}"`）。
+        - 利用可能なプレースホルダー: `{issue_number}`, `{session_id}`, `{branch_name}`, `{project_name}`, `{worktree_path}`
 - [ ] **Cleanup Task**: 不要になったタスク（Worktree + Branch + Tmux Session）をVive上から安全に削除する。
 - [ ] **Safety**: `main`, `master` などのデフォルトブランチの誤削除を防止する.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,24 +51,92 @@ pub struct TerminalConfig {
 }
 
 /// Auto-kickstart configuration for task creation.
+///
+/// Supported placeholders for both `manual_command` and `issue_command`:
+/// - `{issue_number}` - The GitHub issue number (issue_command only)
+/// - `{session_id}` - The tmux session identifier (e.g., `vive__feature-issue-123`)
+/// - `{branch_name}` - The git branch name (e.g., `feature/issue-123`)
+/// - `{project_name}` - The project name (e.g., `vive`)
+/// - `{worktree_path}` - Absolute path to the worktree
+///
+/// Example configuration:
+/// ```toml
+/// [auto_kickstart]
+/// # Start claude directly with the fix command
+/// issue_command = "claude \"/fix {issue_number}\""
+///
+/// # Or use a custom wrapper script
+/// # issue_command = "~/.local/bin/start-agent.sh {session_id} {issue_number}"
+/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AutoKickstartConfig {
     /// Command to send for manual task creation.
+    ///
+    /// Supports placeholders: `{session_id}`, `{branch_name}`, `{project_name}`, `{worktree_path}`
     /// Default: empty (disabled)
     pub manual_command: String,
 
     /// Command to send for issue-based task creation.
-    /// Use `{issue_number}` as placeholder for the issue number.
+    ///
+    /// Supports placeholders: `{issue_number}`, `{session_id}`, `{branch_name}`,
+    /// `{project_name}`, `{worktree_path}`
     /// Default: empty (disabled)
     pub issue_command: String,
 }
 
 impl AutoKickstartConfig {
     /// Build the issue command with issue number substituted.
+    ///
+    /// DEPRECATED: Use `build_issue_command_full` for full placeholder support.
     pub fn build_issue_command(&self, issue_number: u32) -> String {
         self.issue_command
             .replace("{issue_number}", &issue_number.to_string())
+    }
+
+    /// Build the issue command with all placeholders substituted.
+    ///
+    /// Supported placeholders:
+    /// - `{issue_number}` - The issue number
+    /// - `{session_id}` - The tmux session ID (e.g., "project__branch")
+    /// - `{branch_name}` - The git branch name
+    /// - `{project_name}` - The project name
+    /// - `{worktree_path}` - The absolute path to the worktree
+    pub fn build_issue_command_full(
+        &self,
+        issue_number: u32,
+        session_id: &str,
+        branch_name: &str,
+        project_name: &str,
+        worktree_path: &str,
+    ) -> String {
+        self.issue_command
+            .replace("{issue_number}", &issue_number.to_string())
+            .replace("{session_id}", session_id)
+            .replace("{branch_name}", branch_name)
+            .replace("{project_name}", project_name)
+            .replace("{worktree_path}", worktree_path)
+    }
+
+    /// Build the manual command with all placeholders substituted.
+    ///
+    /// Supported placeholders:
+    /// - `{session_id}` - The tmux session ID (e.g., "project__branch")
+    /// - `{branch_name}` - The git branch name
+    /// - `{project_name}` - The project name
+    /// - `{worktree_path}` - The absolute path to the worktree
+    pub fn build_manual_command_full(
+        &self,
+        session_id: &str,
+        branch_name: &str,
+        project_name: &str,
+        worktree_path: &str,
+    ) -> String {
+        self.manual_command
+            .replace("{session_id}", session_id)
+            .replace("{branch_name}", branch_name)
+            .replace("{project_name}", project_name)
+            .replace("{worktree_path}", worktree_path)
     }
 }
 
@@ -820,5 +888,117 @@ enter = "tmux switch-client -t {session_id}"
     fn test_config_includes_auto_kickstart() {
         let config = Config::default();
         assert_eq!(config.auto_kickstart.manual_command, "");
+    }
+
+    // ========================================================================
+    // TDD: Issue #76 - Configurable one-liner kickstart command
+    // ========================================================================
+
+    #[test]
+    fn test_build_issue_command_full_all_placeholders() {
+        let config = AutoKickstartConfig {
+            manual_command: String::new(),
+            issue_command: "claude \"/fix {issue_number}\" --session {session_id}".to_string(),
+        };
+        let result = config.build_issue_command_full(
+            42,
+            "myproject__feature-issue-42",
+            "feature/issue-42",
+            "myproject",
+            "/home/user/src/myproject/.worktrees/feature/issue-42",
+        );
+        assert_eq!(
+            result,
+            "claude \"/fix 42\" --session myproject__feature-issue-42"
+        );
+    }
+
+    #[test]
+    fn test_build_issue_command_full_with_worktree_path() {
+        let config = AutoKickstartConfig {
+            manual_command: String::new(),
+            issue_command: "cd {worktree_path} && claude \"/fix {issue_number}\"".to_string(),
+        };
+        let result = config.build_issue_command_full(
+            99,
+            "proj__issue-99",
+            "issue-99",
+            "proj",
+            "/path/to/worktree",
+        );
+        assert_eq!(result, "cd /path/to/worktree && claude \"/fix 99\"");
+    }
+
+    #[test]
+    fn test_build_issue_command_full_with_project_and_branch() {
+        let config = AutoKickstartConfig {
+            manual_command: String::new(),
+            issue_command: "echo {project_name}:{branch_name} && claude".to_string(),
+        };
+        let result = config.build_issue_command_full(
+            1,
+            "vive__feature-branch",
+            "feature-branch",
+            "vive",
+            "/tmp/worktree",
+        );
+        assert_eq!(result, "echo vive:feature-branch && claude");
+    }
+
+    #[test]
+    fn test_build_manual_command_full_with_placeholders() {
+        let config = AutoKickstartConfig {
+            manual_command: "claude --project {project_name} --cwd {worktree_path}".to_string(),
+            issue_command: String::new(),
+        };
+        let result =
+            config.build_manual_command_full("proj__branch", "branch", "proj", "/path/to/worktree");
+        assert_eq!(result, "claude --project proj --cwd /path/to/worktree");
+    }
+
+    #[test]
+    fn test_build_manual_command_full_with_session_id() {
+        let config = AutoKickstartConfig {
+            manual_command: "tmux send-keys -t {session_id} 'claude' Enter".to_string(),
+            issue_command: String::new(),
+        };
+        let result = config.build_manual_command_full(
+            "my-project__my-branch",
+            "my-branch",
+            "my-project",
+            "/home/user/project",
+        );
+        assert_eq!(
+            result,
+            "tmux send-keys -t my-project__my-branch 'claude' Enter"
+        );
+    }
+
+    #[test]
+    fn test_build_issue_command_full_simple_command() {
+        // Test the typical use case from issue #76
+        let config = AutoKickstartConfig {
+            manual_command: String::new(),
+            issue_command: "claude \"/fix {issue_number}\"".to_string(),
+        };
+        let result = config.build_issue_command_full(
+            76,
+            "vive__feature-issue-76",
+            "feature/issue-76",
+            "vive",
+            "/Users/user/src/vive/.worktrees/feature/issue-76",
+        );
+        assert_eq!(result, "claude \"/fix 76\"");
+    }
+
+    #[test]
+    fn test_build_issue_command_full_no_placeholders() {
+        // Empty placeholders should just return the template as-is
+        let config = AutoKickstartConfig {
+            manual_command: String::new(),
+            issue_command: "claude --interactive".to_string(),
+        };
+        let result = config.build_issue_command_full(42, "session", "branch", "project", "/path");
+        assert_eq!(result, "claude --interactive");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,11 +313,16 @@ where
                             let _ = self.tmux.add_pane_to_dashboard(&project.name, &session_id);
 
                             // Auto-kickstart: send initial command if enabled and configured
-                            if auto_kickstart {
-                                let command = &self.config.auto_kickstart.manual_command;
-                                if !command.is_empty() {
-                                    let _ = self.tmux.send_keys(&session_id, command, true);
-                                }
+                            if auto_kickstart
+                                && !self.config.auto_kickstart.manual_command.is_empty()
+                            {
+                                let command = self.config.auto_kickstart.build_manual_command_full(
+                                    &session_id,
+                                    &branch_name,
+                                    &project.name,
+                                    &worktree_path.to_string_lossy(),
+                                );
+                                let _ = self.tmux.send_keys(&session_id, &command, true);
                             }
 
                             self.state
@@ -410,16 +415,17 @@ where
                                 .ensure_session(&session_id, Some(&worktree_path_str));
                             let _ = self.tmux.add_pane_to_dashboard(&project.name, &session_id);
 
-                            // Auto-kickstart: start Claude and send issue command if configured
+                            // Auto-kickstart: execute the configured one-liner command
                             if auto_kickstart
                                 && !self.config.auto_kickstart.issue_command.is_empty()
                             {
-                                // First, start Claude CLI
-                                let _ = self.tmux.send_keys(&session_id, "claude", true);
-                                // Then send issue command after a brief delay for Claude to start
-                                // Note: The command will be queued and processed once Claude is ready
-                                let command =
-                                    self.config.auto_kickstart.build_issue_command(issue.number);
+                                let command = self.config.auto_kickstart.build_issue_command_full(
+                                    issue.number,
+                                    &session_id,
+                                    &branch_name,
+                                    &project.name,
+                                    &worktree_path.to_string_lossy(),
+                                );
                                 let _ = self.tmux.send_keys(&session_id, &command, true);
                             }
 


### PR DESCRIPTION
## Summary
- Add `build_issue_command_full` and `build_manual_command_full` methods to `AutoKickstartConfig` supporting all placeholders: `{issue_number}`, `{session_id}`, `{branch_name}`, `{project_name}`, `{worktree_path}`
- Remove hardcoded "claude" execution from `CreateTaskFromIssue` action - users can now specify the full command in config
- Update `CreateTask` action to use the new placeholder substitution method for `manual_command`

## Test plan
- [x] Unit tests for new `build_issue_command_full` method with all placeholder combinations
- [x] Unit tests for new `build_manual_command_full` method
- [x] Backward compatibility tests pass (existing `build_issue_command` still works)
- [x] All existing tests pass (385 lib tests + 86 integration tests)
- [x] cargo clippy passes with no warnings
- [x] cargo fmt passes

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)