### PR TITLE
docs: add CONTRIBUTING and SECURITY

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+## Contributing
+
+ありがとうございます！vive への貢献は歓迎です。
+
+### できること
+
+- バグ報告 / 改善提案（Issue）
+- ドキュメント改善（README / `docs/`）
+- 実装改善（PR）
+
+### 開発環境
+
+- Rust (stable)
+- git
+- tmux
+
+### セットアップ
+
+```bash
+git clone https://github.com/k4h4shi/vive.git
+cd vive
+./install.sh
+```
+
+### ローカルでの確認
+
+PR 前に最低限、以下が通ることを確認してください。
+
+```bash
+cargo fmt -- --check
+cargo clippy -- -D warnings
+cargo test
+```
+
+### PR ガイド
+
+- **目的が伝わるタイトル/説明**にしてください（Why を重視）
+- 変更が大きい場合は **Issue を先に立てる**（設計/方向性のすり合わせ）
+- UI/TUI の変更は、可能であれば **スクリーンショット**を添付してください
+- 仕様/使い方が変わる場合は **README / docs の更新**も含めてください
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+## Security Policy
+
+### Supported Versions
+
+最新の `main` ブランチをサポート対象とします。
+
+### Reporting a Vulnerability
+
+脆弱性の可能性がある問題を見つけた場合は、公開 Issue に投稿せず、GitHub の **Private vulnerability reporting**（Security Advisories）からご連絡ください。
+
+- 可能なら **再現手順 / 影響範囲 / 想定される悪用シナリオ** を添えてください
+- こちらで確認後、必要に応じて修正版のリリースやアナウンスを行います
+


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` with local dev and PR guidelines.
- Add `SECURITY.md` with vulnerability reporting policy.

## Test plan
- N/A (docs-only)