### PR TITLE
feat: add configurable base branch for worktree creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ cd vive
 # プロジェクトのルートディレクトリ
 projects_root = "~/src/github"
 
+# Worktree作成時のベースブランチ (省略時は現在のHEADから作成)
+# base_branch = "develop"
+
 # キーバインド設定
 [keybindings]
 # Enterキーでタスクを開く時のコマンド (Ghosttyの例)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,3 +105,24 @@ n = "code {path}"
 *   キーごとに異なるアプリケーションで開く
 *   タスク作成直後に `npm install` を走らせる
 *   タスク作成直後に Claude Code を起動してプロンプトを流し込む
+
+### Base Branch (ベースブランチ)
+
+Worktree作成時のベースブランチを設定できます。
+
+#### 設定例
+
+```toml
+# Worktree作成時のベースブランチ (省略時は現在のHEADから作成)
+base_branch = "develop"
+```
+
+#### 動作
+
+- **設定あり**: `git worktree add -b <branch> <path> <base_branch>` で指定されたベースブランチから分岐
+- **設定なし**: `git worktree add -b <branch> <path>` で現在のHEADから分岐（デフォルト動作）
+
+#### ユースケース
+
+- `develop` ブランチをベースにしたい場合（例: mechanix）
+- プロジェクトごとに異なる開発フローに対応

--- a/src/config.rs
+++ b/src/config.rs
@@ -207,6 +207,15 @@ pub struct Config {
     /// ```
     #[serde(default)]
     pub auto_kickstart: AutoKickstartConfig,
+
+    /// Base branch for worktree creation.
+    /// If set, new worktrees will be created from this branch instead of the current HEAD.
+    ///
+    /// Example:
+    /// ```toml
+    /// base_branch = "develop"
+    /// ```
+    pub base_branch: Option<String>,
 }
 
 impl Default for Config {
@@ -218,6 +227,7 @@ impl Default for Config {
             terminal: TerminalConfig::default(),
             keybindings: HashMap::new(),
             auto_kickstart: AutoKickstartConfig::default(),
+            base_branch: None,
         }
     }
 }
@@ -287,6 +297,10 @@ ignored_dirs = [".git", "node_modules", ".worktrees", "target", "dist"]
 
 # Optional tmux prefix key override (e.g., "C-a" for Ctrl+a)
 # tmux_prefix = "C-a"
+
+# Base branch for worktree creation (defaults to current HEAD if not set)
+# If set, new worktrees will be created from this branch
+# base_branch = "develop"
 
 # Custom keybindings for opening sessions
 # Use {session_id} as placeholder for the target session name
@@ -1000,5 +1014,39 @@ enter = "tmux switch-client -t {session_id}"
         };
         let result = config.build_issue_command_full(42, "session", "branch", "project", "/path");
         assert_eq!(result, "claude --interactive");
+    }
+
+    // ========================================================================
+    // TDD: Issue #88 - Configurable base branch for worktree creation
+    // ========================================================================
+
+    #[test]
+    fn test_base_branch_default_is_none() {
+        let config = Config::default();
+        assert!(config.base_branch.is_none());
+    }
+
+    #[test]
+    fn test_parse_base_branch_from_toml() {
+        let toml_content = r#"
+base_branch = "develop"
+"#;
+        let config: Config = toml::from_str(toml_content).unwrap();
+        assert_eq!(config.base_branch, Some("develop".to_string()));
+    }
+
+    #[test]
+    fn test_parse_base_branch_with_other_configs() {
+        let toml_content = r#"
+projects_root = "/home/user/projects"
+base_branch = "main"
+ignored_dirs = [".git"]
+"#;
+        let config: Config = toml::from_str(toml_content).unwrap();
+        assert_eq!(config.base_branch, Some("main".to_string()));
+        assert_eq!(
+            config.projects_root,
+            Some(PathBuf::from("/home/user/projects"))
+        );
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1210,7 +1210,7 @@ mod tests {
             Action::CreateTaskFromIssue(issue, _) => {
                 assert_eq!(issue.number, 2);
             }
-            _ => panic!("Expected CreateTaskFromIssue action, got {:?}", action),
+            _ => panic!("Expected CreateTaskFromIssue action, got {action:?}"),
         }
     }
 
@@ -1235,7 +1235,7 @@ mod tests {
             Action::CreateTaskFromIssue(issue, _) => {
                 assert_eq!(issue.number, 1);
             }
-            _ => panic!("Expected CreateTaskFromIssue action, got {:?}", action),
+            _ => panic!("Expected CreateTaskFromIssue action, got {action:?}"),
         }
     }
 
@@ -1269,7 +1269,7 @@ mod tests {
                 assert!(numbers.contains(&3));
                 assert!(auto_kickstart); // Default is true
             }
-            _ => panic!("Expected CreateTasksFromIssues action, got {:?}", action),
+            _ => panic!("Expected CreateTasksFromIssues action, got {action:?}"),
         }
     }
 
@@ -1298,7 +1298,7 @@ mod tests {
             Action::CreateTasksFromIssues(_, auto_kickstart) => {
                 assert!(!auto_kickstart);
             }
-            _ => panic!("Expected CreateTasksFromIssues action, got {:?}", action),
+            _ => panic!("Expected CreateTasksFromIssues action, got {action:?}"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,14 +283,23 @@ where
             Action::CreateTask(branch_name, auto_kickstart) => {
                 if let Some(project) = self.state.selected_project().cloned() {
                     let worktree_path = project.path.join(".worktrees").join(&branch_name);
+
+                    // Build git worktree command with optional base branch
+                    let mut args = vec![
+                        "worktree".to_string(),
+                        "add".to_string(),
+                        "-b".to_string(),
+                        branch_name.clone(),
+                        worktree_path.to_string_lossy().to_string(),
+                    ];
+
+                    // Add base branch if configured
+                    if let Some(ref base) = self.config.base_branch {
+                        args.push(base.clone());
+                    }
+
                     let output = std::process::Command::new("git")
-                        .args([
-                            "worktree",
-                            "add",
-                            "-b",
-                            &branch_name,
-                            &worktree_path.to_string_lossy(),
-                        ])
+                        .args(&args)
                         .current_dir(&project.path)
                         .output();
 
@@ -386,14 +395,23 @@ where
                 // Reuse the CreateTask logic
                 if let Some(project) = self.state.selected_project().cloned() {
                     let worktree_path = project.path.join(".worktrees").join(&branch_name);
+
+                    // Build git worktree command with optional base branch
+                    let mut args = vec![
+                        "worktree".to_string(),
+                        "add".to_string(),
+                        "-b".to_string(),
+                        branch_name.clone(),
+                        worktree_path.to_string_lossy().to_string(),
+                    ];
+
+                    // Add base branch if configured
+                    if let Some(ref base) = self.config.base_branch {
+                        args.push(base.clone());
+                    }
+
                     let output = std::process::Command::new("git")
-                        .args([
-                            "worktree",
-                            "add",
-                            "-b",
-                            &branch_name,
-                            &worktree_path.to_string_lossy(),
-                        ])
+                        .args(&args)
                         .current_dir(&project.path)
                         .output();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1998,7 +1998,7 @@ mod tests {
         let text = status.status_text();
 
         // Should be truncated to max 20 chars + "..."
-        assert!(text.len() < format!("Working ({})", long_detail).len());
+        assert!(text.len() < format!("Working ({long_detail})").len());
         assert!(text.contains("..."));
         assert!(text.starts_with("Working ("));
         assert!(text.ends_with(")"));
@@ -2014,7 +2014,7 @@ mod tests {
         let text = status.status_text();
 
         // Should be truncated
-        assert!(text.len() < format!("Wait: {}", long_command).len());
+        assert!(text.len() < format!("Wait: {long_command}").len());
         assert!(text.contains("..."));
     }
 

--- a/tests/tui_integration.rs
+++ b/tests/tui_integration.rs
@@ -2328,7 +2328,7 @@ fn test_issue_picker_select_creates_task() {
             assert_eq!(issue.branch_name(), "feature/issue-42");
             assert!(auto_kickstart); // Default is true
         }
-        _ => panic!("Expected CreateTaskFromIssue action, got {:?}", action),
+        _ => panic!("Expected CreateTaskFromIssue action, got {action:?}"),
     }
 
     // Modal should be closed


### PR DESCRIPTION
## 概要

タスク作成時に使用するベースブランチを `config.toml` で設定できるようにしました。

## 変更内容

- `Config` 構造体に `base_branch: Option<String>` を追加
- worktree作成コマンドを変更:
  - 設定あり: `git worktree add -b <branch> <path> <base_branch>`
  - 設定なし: `git worktree add -b <branch> <path>` (デフォルト動作を維持)

## 設定例

```toml
# Worktree作成時のベースブランチ (省略時は現在のHEADから作成)
base_branch = "develop"
```

## ユースケース

- `develop` ブランチをベースにしたいプロジェクト: Githubフロー以外にも対応
- プロジェクトごとに異なる開発フローに対応

## テスト

- ユニットテスト追加 (config解析のテスト)
- 既存テスト全て成功 (499 tests passed)

## その他

- Clippy警告 (uninlined_format_args) を修正

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)